### PR TITLE
add uv command

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -17,7 +17,7 @@ API_KEY = os.environ.get("API_KEY")
 
 logging.basicConfig(level=logging.INFO)
 mcp_base_url = os.environ.get('MCP_BASE_URL')
-mcp_command_list = ["uvx", "npx", "node", "python","docker"]
+mcp_command_list = ["uvx", "npx", "node", "python","docker","uv"]
 
 def request_list_models():
     url = mcp_base_url.rstrip('/') + '/v1/list/models'

--- a/src/main.py
+++ b/src/main.py
@@ -79,7 +79,7 @@ class ChatResponse(BaseModel):
 class AddMCPServerRequest(BaseModel):
     server_id: str = ''
     server_desc: str
-    command: Literal["npx", "uvx", "node", "python","docker"] = Field(default='npx')
+    command: Literal["npx", "uvx", "node", "python","docker","uv"] = Field(default='npx')
     args: List[str] = []
     env: Optional[Dict[str, str]] = Field(default_factory=dict) 
     config_json: Dict[str,Any] = Field(default_factory=dict)

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -91,13 +91,14 @@ class MCPClient:
             # run via script
             is_python = server_script_path.endswith('.py')
             is_js = server_script_path.endswith('.js')
-            is_uv = server_script_path.startswith('uvx:')
+            is_uvx = server_script_path.startswith('uvx:')
             is_np = server_script_path.startswith('npx:')
             is_docker = server_script_path.startswith('docker:')
+            is_uv = server_script_path.startswith('uv:')
 
-            if not (is_python or is_js or is_uv or is_np or is_docker):
+            if not (is_python or is_js or is_uv or is_np or is_docker or is_uvx):
                 raise ValueError("Server script must be a .py or .js file or package")
-            if is_uv or is_np:
+            if is_uv or is_np or is_uvx:
                 server_script_path = server_script_path[server_script_path.index(':')+1:]
 
             server_script_args = [server_script_path] + server_script_args
@@ -105,6 +106,8 @@ class MCPClient:
             if is_python:
                 command = "python"
             elif is_uv:
+                command = "uv"
+            elif is_uvx:
                 command = "uvx"
             elif is_np:
                 command = "npx"
@@ -115,8 +118,8 @@ class MCPClient:
                 command = "docker"
         else:
             # run via command
-            if command not in ["npx", "uvx", "node", "python","docker"]:
-                raise ValueError("Server command must be in the npx/uvx/node/python/docker")
+            if command not in ["npx", "uvx", "node", "python","docker","uv",]:
+                raise ValueError("Server command must be in the npx/uvx/node/python/docker/uv")
 
         env = get_default_environment()
         if self.env['AWS_ACCESS_KEY_ID'] and self.env['AWS_ACCESS_KEY_ID']:


### PR DESCRIPTION
*Issue #, if available:*
I built a mcp server according the demo of " https://modelcontextprotocol.io/quickstart/server" , When i wanted to add the mcp server with console which can't  select the uv command. 
*Description of changes:*
support uv command for the project , then we can add the mcp server built with uv .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
